### PR TITLE
feat(simple-sbom): write sbom to artifacts dir

### DIFF
--- a/recipes/simple-sbom/steps/00-install.sh
+++ b/recipes/simple-sbom/steps/00-install.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-SBOM_PATH="${RUGIX_PROJECT_DIR}${RECIPE_PARAM_SBOM_FILE}"
+SBOM_PATH="${RUGIX_ARTIFACTS_DIR}/${RECIPE_PARAM_SBOM_FILE}"
 SBOM_DIR=$(dirname "${SBOM_PATH}")
 
 if [ ! -d "${SBOM_DIR}" ]; then


### PR DESCRIPTION
Updating the simple-sbom recipe to use the newer `RUGIX_ARTIFACTS_DIR` env variable (taken from the test from https://github.com/silitics/rugpi/blob/main/tests/recipes/simple-sbom/steps/00-install.sh).

This also fixes a previous problem with the building of the SBOM_PATH which was missing a slash `/` between the directory and sbom filename/path.